### PR TITLE
Update To latest version of Antidote java client (0.3.0)

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     compile 'com.google.guava:guava:20.0'
     
     //Antidote java client library
-    compile group: 'eu.antidotedb', name: 'antidote-java-client', version: '0.1.0'
+    compile group: 'eu.antidotedb', name: 'antidote-java-client', version: '0.3.0'
     
     //for command line shell
     compile files("lib/asg.cliche-110413.jar")

--- a/application/build.gradle
+++ b/application/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     compile 'com.google.guava:guava:20.0'
     
     //Antidote java client library
-    compile group: 'eu.antidotedb', name: 'antidote-java-client', version: '0.1.0-SNAPSHOT'
+    compile group: 'eu.antidotedb', name: 'antidote-java-client', version: '0.1.0'
     
     //for command line shell
     compile files("lib/asg.cliche-110413.jar")

--- a/application/src/main/java/common/Board.java
+++ b/application/src/main/java/common/Board.java
@@ -1,9 +1,5 @@
 package common;
 
-import static eu.antidotedb.client.Key.map_aw;
-import static eu.antidotedb.client.Key.register;
-import static eu.antidotedb.client.Key.set;
-
 import java.util.ArrayList;
 import java.util.List;
 import eu.antidotedb.client.AntidoteClient;
@@ -12,6 +8,10 @@ import eu.antidotedb.client.MapKey;
 import eu.antidotedb.client.MapKey.MapReadResult;
 import eu.antidotedb.client.RegisterKey;
 import eu.antidotedb.client.SetKey;
+
+import static eu.antidotedb.client.Key.map_rr;
+import static eu.antidotedb.client.Key.register;
+import static eu.antidotedb.client.Key.set;
 
 public class Board {
 
@@ -22,7 +22,7 @@ public class Board {
 	public static List<BoardId> list_boards = new ArrayList<BoardId>();
 
 	public static MapKey boardMap(BoardId board_id) {
-		return map_aw(board_id.getId());
+		return map_rr(board_id.getId());
 	}
 
 	public BoardId createBoard(AntidoteClient client, String name) {

--- a/application/src/main/java/common/Column.java
+++ b/application/src/main/java/common/Column.java
@@ -1,6 +1,6 @@
 package common;
 
-import static eu.antidotedb.client.Key.map_aw;
+import static eu.antidotedb.client.Key.map_rr;
 import static eu.antidotedb.client.Key.register;
 import static eu.antidotedb.client.Key.set;
 
@@ -31,7 +31,7 @@ public class Column {
 		}
 
 		public static MapKey columnMap(ColumnId column_id) {
-			return map_aw(column_id.getId());
+			return map_rr(column_id.getId());
 		}
 
 		public ColumnId addColumn(AntidoteClient client, BoardId board_id, String name) {

--- a/application/src/main/java/common/Task.java
+++ b/application/src/main/java/common/Task.java
@@ -1,6 +1,6 @@
 package common;
 
-import static eu.antidotedb.client.Key.map_aw;
+import static eu.antidotedb.client.Key.map_rr;
 import static eu.antidotedb.client.Key.register;
 
 import java.text.DateFormat;
@@ -30,7 +30,7 @@ public class Task {
 	}
 
 	public static MapKey taskMap(TaskId task_id) {
-		return map_aw(task_id.getId());
+		return map_rr(task_id.getId());
 	}
 
 	public TaskId createTask(AntidoteClient client, ColumnId column_id, String title) {

--- a/application/src/main/java/common/User.java
+++ b/application/src/main/java/common/User.java
@@ -2,7 +2,8 @@ package common;
 
 import eu.antidotedb.client.AntidoteClient;
 import eu.antidotedb.client.Bucket;
-import static eu.antidotedb.client.Key.*;
+import static eu.antidotedb.client.Key.register;
+import static eu.antidotedb.client.Key.map_rr;
 import eu.antidotedb.client.MapKey;
 import eu.antidotedb.client.RegisterKey;
 
@@ -21,7 +22,7 @@ public class User {
 	}
 
 	public MapKey userMap(UserId user_id) {
-		return map_aw(user_id.getId());
+		return map_rr(user_id.getId());
 	}
 
 	public UserId createUser(AntidoteClient client, String email) {

--- a/setup/docker-compose.yml
+++ b/setup/docker-compose.yml
@@ -59,8 +59,7 @@ services:
     cap_add:
       - NET_ADMIN
     networks:
-      - local1
-      - local2
+      - interdc
 
 networks:
   interdc:

--- a/setup/docker-compose.yml
+++ b/setup/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2"
 services:
   antidote1:
-     image: mweber/antidotedb:latest
+     image: antidotedb/antidote:latest
      ports:
        - "8087:8087"
      environment:
@@ -14,7 +14,7 @@ services:
        - local1
 
   antidote2:
-    image: mweber/antidotedb:latest
+    image: antidotedb/antidote:latest
     ports:
       - "8088:8087"
     environment:


### PR DESCRIPTION
+ Fix build.gradle dependency crash
+ Fix docker link service: should use interdc network to connect the two Antidote images.
+ update Antidote Docker image source repo link.
+ replaced map_aw by map_rr (CRDT lib is not backward compatible), to support the latest (0.3.0) version of Antidote java client.